### PR TITLE
pc - add $PORT command to you can deploy to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@ This is a starter template for [Learn Next.js](https://nextjs.org/learn).
 
 These likely will not work until initial configuration is done per instructions below.
 
-| Command                | Description                                  |
-| ---------------------- | -------------------------------------------- |
-| `npm install`          | Install Dependencies                         |
-| `npm run dev`          | Runs locally                                 |
-| `npm run test`         | Runs entire test suite                       |
-| `npm run test:cypress` | Runs Cypress integration tests               |
-| `npm run test:cypress` | Runs `prettier` format tests                 |
-| `npm run fix:format`   | Reformats all project files using `prettier` |
+| Command                | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `npm install`          | Install Dependencies                              |
+| `npm run dev`          | Runs locally in development mode                  |
+| `npm run start`        | Runs in production mode (requires `PORT` env var) |
+| `npm run test`         | Runs entire test suite                            |
+| `npm run test:cypress` | Runs Cypress integration tests                    |
+| `npm run test:cypress` | Runs `prettier` format tests                      |
+| `npm run fix:format`   | Reformats all project files using `prettier`      |
+
+Note that while no environment variables are required to run
+`npm run dev`, running `npm run start` requires that the `PORT` environment
+variable be set first, e.g.
+
+```
+export PORT=3000
+```
 
 # Initial Configuration
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p $PORT",
     "fix:format": "prettier --write \"**/*.{js,json,md}\" --ignore-path .gitignore",
     "cy:run": "cypress run",
     "test": "npm-run-all test:*",


### PR DESCRIPTION
To be able to deploy to Heroku, it is necessary for the `next start` command to have the `-p $PORT` parameter.

On Heroku, the server must start up on the port number assigned through the `PORT` environment variable.  The value is chosen internally Heroku, and then exposed on the default port (port `80`) to the outside world.

Additional changes may be necessary as/when there are dependencies on environment variables (e.g. to deploy OAuth or other external services requiring secret values.) 