### PR TITLE
pc - fix GitHub repo link

### DIFF
--- a/components/AppFooter.js
+++ b/components/AppFooter.js
@@ -26,7 +26,7 @@ function AppFooter() {
                 <a>this tutorial</a>
               </Link>
               . Check out the source code on{" "}
-              <Link href="https://github.com/pconrad/nextjs-tutorial">
+              <Link href="https://github.com/ucsb-cs48-s20/cs48-s20-nextjs-tutorial">
                 <a>GitHub</a>
               </Link>
               {"."}


### PR DESCRIPTION
In this PR, we update the link to the GitHub repo that appears in the footer to point to the repo we are now using.